### PR TITLE
Laat naam van functie zien in plaats van code

### DIFF
--- a/app/controllers/ledenlijst-controller.js
+++ b/app/controllers/ledenlijst-controller.js
@@ -671,6 +671,13 @@
           function(res){
             $scope.aantalLedenGeladen = $scope.aantalPerPagina;
             _.each(res.leden, function(val,key){
+              //Laat naam van functie zien in plaats van code
+              _.each(val.waarden, function(waardeVal,waarde){
+                if (waarde.toLowerCase().includes("funkties")){
+                  var beschrijving = $scope.functies.filter(x => x.code === waardeVal)[0].beschrijving;
+                  val.waarden[waarde] = beschrijving;
+                }
+              })
               $scope.leden.push(val);
             })
             $scope.totaalAantalLeden = res.totaal;


### PR DESCRIPTION
Eerste probeersel om een aanpassing te maken.
De code's van de functies zeiden niet direct wat het was, nu zijn ze de functienaam volledig uitgeschreven